### PR TITLE
Feature proxy setup

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 var request = require('request');
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var xml2js = require('xml2js');
+var HttpsProxyAgent = require('https-proxy-agent');
 
 module.exports = {
   /**
@@ -39,6 +40,11 @@ module.exports = {
 
     if (typeof client.config.userAgent !== 'undefined') {
       serverOptions.headers['User-Agent'] = client.config.userAgent;
+    }
+
+    if(options.proxy_url)
+    {
+      serverOptions.agent = new HttpsProxyAgent(options.proxy_url);
     }
 
     serverOptions.headers['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,6 +45,7 @@ module.exports = {
     if(options.proxy_url)
     {
       serverOptions.agent = new HttpsProxyAgent(options.proxy_url);
+      serverOptions.followRedirect = true;
     }
 
     serverOptions.headers['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,9 +42,9 @@ module.exports = {
       serverOptions.headers['User-Agent'] = client.config.userAgent;
     }
 
-    if(options.proxy_url)
+    if(client.config.proxy_url)
     {
-      serverOptions.agent = new HttpsProxyAgent(options.proxy_url);
+      serverOptions.agent = new HttpsProxyAgent(client.config.proxy_url);
       serverOptions.followRedirect = true;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -559,6 +577,25 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -797,8 +834,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "node-environment-flags": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "hosting"
   ],
   "dependencies": {
+    "https-proxy-agent": "^5.0.0",
     "request": "^2.88.0",
     "xml2js": "0.4.x"
   },

--- a/whmcs.js
+++ b/whmcs.js
@@ -3,7 +3,7 @@ var libPath = __dirname + '/modules';
 
 /**
  * WHMCS client
- * @param options {{username:String,serverUrl:String,password:String,apiKey:[String]}}
+ * @param options {{username:String,serverUrl:String,password:String,proxy_url:String,apiKey:[String]}}
  */
 var WHMCS = function(options) {
   var _this = this;


### PR DESCRIPTION
To access WHMCS API, client should have static IP address.
But some platform, like Heroku gives dynamic ip into app instance.
In this case, we can use https_proxy_service, to invoke WHMCS API.
So I added proxy_url options.